### PR TITLE
Added capability to set Y position to SCM hurricane test

### DIFF
--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -71,9 +71,9 @@ IO_LAYOUT = 0, 0                ! default = 0
 
 ! === module MOM_grid ===
 ! Parameters providing information about the vertical grid.
-G_EARTH = 9.8                   !   [m s-2] default = 9.8
+G_EARTH = 9.81                  !   [m s-2] default = 9.8
                                 ! The gravitational acceleration of the Earth.
-RHO_0 = 1035.0                  !   [kg m-3] default = 1035.0
+RHO_0 = 1027.0                  !   [kg m-3] default = 1035.0
                                 ! The mean ocean density used with BOUSSINESQ true to
                                 ! calculate accelerations and the mass for conservation
                                 ! properties, or with BOUSSINSEQ false to convert some
@@ -91,7 +91,7 @@ BATHYMETRY_AT_VEL = False       !   [Boolean] default = False
                                 ! If true, there are separate values for the basin depths
                                 ! at velocity points.  Otherwise the effects of of
                                 ! topography are entirely determined from thickness points.
-NK = 75                         !   [nondim]
+NK = 600                        !   [nondim]
                                 ! The number of model layers.
 NIBLOCK = 1                     ! default = 1
                                 ! The number of blocks in the x-direction on each processor (for openmp).
@@ -105,7 +105,7 @@ AVAILABLE_DIAGS_FILE = "available_diags.000000" ! default = "available_diags.000
                                 ! ocean diagnostics that can be included in a diag_table.
 
 ! === module MOM ===
-VERBOSITY = 9                   ! default = 2
+VERBOSITY = 2                   ! default = 2
                                 ! Integer controlling level of messaging
                                 !   0 = Only FATAL messages
                                 !   2 = Only FATAL, WARNING, NOTE [default]
@@ -214,7 +214,7 @@ EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
 RHO_T0_S0 = 1000.0              !   [kg m-3] default = 1000.0
                                 ! When EQN_OF_STATE=LINEAR,
                                 ! this is the density at T=0, S=0.
-DRHO_DT = -0.255                !   [kg m-3 K-1] default = -0.2
+DRHO_DT = -0.2                  !   [kg m-3 K-1] default = -0.2
                                 ! When EQN_OF_STATE=LINEAR,
                                 ! this is the partial derivative of density with
                                 ! temperature.
@@ -299,7 +299,7 @@ AXIS_UNITS = "degrees"          ! default = "degrees"
                                 !     degrees - degrees of latitude and longitude
                                 !     m - meters
                                 !     k - kilometers
-SOUTHLAT = 30.0                 !   [degrees]
+SOUTHLAT = 27.836               !   [degrees]
                                 ! The southern latitude of the domain or the equivalent
                                 ! starting value for the y-axis.
 LENLAT = 2.0                    !   [degrees]
@@ -331,7 +331,7 @@ TOPO_CONFIG = "flat"            !
                                 !     USER - call a user modified routine.
 MINIMUM_DEPTH = 0.5             !   [m] default = 0.0
                                 ! The minimum depth of the ocean.
-MAXIMUM_DEPTH = 6000.0          !   [m]
+MAXIMUM_DEPTH = 300.0           !   [m]
                                 ! The maximum depth of the ocean.
 MASKING_DEPTH = -9999.0         !   [m] default = -9999.0
                                 ! The depth below which to mask points as land points, for which all
@@ -365,7 +365,7 @@ ROTATION = "betaplane"          ! default = "2omegasinlat"
                                 !       times the sine of latitude.
                                 !     betaplane - Use a beta-plane or f-plane.
                                 !     USER - call a user modified routine.
-F_0 = 1.0E-04                   !   [s-1] default = 0.0
+F_0 = 6.8103E-05                !   [s-1] default = 0.0
                                 ! The reference value of the Coriolis parameter with the
                                 ! betaplane option.
 BETA = 0.0                      !   [m-1 s-1] default = 0.0
@@ -420,11 +420,11 @@ TS_CONFIG = "SCM_ideal_hurr"    !
                                 !     USER - call a user modified routine.
 SCM_S_REF = 35.0                !   [1e-3] default = 35.0
                                 ! Reference salinity
-SCM_SST_REF = 15.0              !   [C]
+SCM_SST_REF = 29.25             !   [C]
                                 ! Reference surface temperature
-SCM_DTDZ = 0.002                !   [C/m]
+SCM_DTDZ = 0.04                 !   [C/m]
                                 ! Initial temperature stratification below mixed layer
-SCM_MLD = 50.0                  !   [m]
+SCM_MLD = 32.0                  !   [m]
                                 ! Initial mixed layer depth
 VELOCITY_CONFIG = "zero"        ! default = "zero"
                                 ! A string that determines how the initial velocities
@@ -502,7 +502,7 @@ ALE_COORDINATE_CONFIG = "FILE:INPUT/vgrid_cm4.nc,dz" ! default = "UNIFORM"
                                 !  FILE:string - read from a file. The string specifies
                                 !                the filename and variable name, separated
                                 !                by a comma or space, e.g. FILE:lev.nc,Z
-!ALE_RESOLUTION = 4*2.0, 2*2.01, 2*2.02, 2.05, 2.07, 2.09, 2.13, 2.18, 2.24, 2.3, 2.4, 2.5, 2.62, 2.78, 2.95, 3.17, 3.42, 3.71, 4.07, 4.48, 4.97, 5.55, 6.23, 7.04, 7.99, 9.11, 10.43, 11.98, 13.8, 15.94, 18.42, 21.32, 24.66, 28.51, 32.91, 37.92, 43.56, 49.87, 56.88, 64.55, 72.91, 81.87, 91.4, 101.39, 111.73, 122.29, 132.93, 143.47, 153.78, 163.7, 173.07, 181.78, 189.76, 196.89, 203.17, 208.58, 213.14, 216.87, 219.87, 222.19, 223.94, 225.18, 226.04, 226.59, 226.9, 227.07, 227.14, 2*227.16, 227.17 !   [m]
+!ALE_RESOLUTION = 600*0.5       !   [m]
                                 ! The distribution of vertical resolution for the target
                                 ! grid used for Eulerian-like coordinates. For example,
                                 ! in z-coordinate mode, the parameter is a list of level
@@ -586,7 +586,7 @@ UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
                                 ! continuity solver.  This scheme is highly diffusive
                                 ! but may be useful for debugging or in single-column
                                 ! mode where its minimal stensil is useful.
-ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.75E-09
+ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.0E-08
                                 ! The tolerance for the differences between the
                                 ! barotropic and baroclinic estimates of the sea surface
                                 ! height due to the fluxes through each face.  The total
@@ -1058,7 +1058,7 @@ USE_KPP = True                  !   [Boolean] default = False
 KPP%
 PASSIVE = False                 !   [Boolean] default = False
                                 ! If True, puts KPP into a passive-diagnostic mode.
-APPLY_NONLOCAL_TRANSPORT = True !   [Boolean] default = True
+APPLY_NONLOCAL_TRANSPORT = False !   [Boolean] default = True
                                 ! If True, applies the non-local transport to heat and scalars.
                                 ! If False, calculates the non-local transport and tendencies but
                                 ! purely for diagnostic purposes.
@@ -1241,6 +1241,8 @@ SCM_RADIUS_MAX_WINDS = 5.0E+04  !   [m] default = 5.0E+04
                                 ! Radius of maximum winds used in the SCM idealized hurricane wind profile.
 SCM_MAX_WIND_SPEED = 65.0       !   [m/s] default = 65.0
                                 ! Maximum wind speed used in the SCM idealized hurricane wind profile.
+SCM_YY = 5.0E+04                !   [m] default = 5.0E+04
+                                ! Y distance of station used in the SCM idealized hurricane wind profile.
 
 ! === module MOM_sum_output ===
 CALCULATE_APE = True            !   [Boolean] default = True
@@ -1287,7 +1289,7 @@ DT_FORCING = 1200.0             !   [s] default = 1200.0
                                 ! The time step for changing forcing, coupling with other
                                 ! components, or potentially writing certain diagnostics.
                                 ! The default value is given by DT.
-DAYMAX = 10.0                   !   [days]
+DAYMAX = 3.0                    !   [days]
                                 ! The final time of the whole simulation, in units of
                                 ! TIMEUNIT seconds.  This also sets the potential end
                                 ! time of the present run segment if the end time is


### PR DESCRIPTION
Other changes include setting the mixing layer to be identical to that used in benchmark simulation.  Additional parameters have also been changed (rho_0, grav) to correspond to those used in benchmark for comparison.
