### PR TITLE
Patches to MIDAS and mkmf for OM4_025 preprocessing

### DIFF
--- a/ice_ocean_SIS2/OM4_025/preprocessing/MIDAS.patch
+++ b/ice_ocean_SIS2/OM4_025/preprocessing/MIDAS.patch
@@ -1,0 +1,66 @@
+diff --git a/MOM6_ALE/build_ale/build_ale.csh b/MOM6_ALE/build_ale/build_ale.csh
+index e464452..34535b2 100755
+--- a/MOM6_ALE/build_ale/build_ale.csh
++++ b/MOM6_ALE/build_ale/build_ale.csh
+@@ -19,8 +19,8 @@ set LISTPATHS    = $root/fms/bin/list_paths
+ 
+ 
+ if ($platform == 'gfdl_hpcs') then
+-  module load netcdf/4.2
+-  module load intel_compilers
++  module load netcdf-fortran/4.5.3
++  module load intel-oneapi-compilers/2022.0.2
+ endif
+ 
+ 
+diff --git a/Makefile_GFDL b/Makefile_GFDL
+index 1054790..6ed2ea8 100644
+--- a/Makefile_GFDL
++++ b/Makefile_GFDL
+@@ -17,10 +17,12 @@ MIDAS:	fms_build/libfms.a MOM6_ALE/build_ale/libale.a
+ 	(python setup.py config_fc --f90flags="-nowarn -i4 -r8 -DPY_SOLO" --fcompiler=intelem build >& /dev/null)
+ 	(python setup.py install --home=$(INSTALL_PATH))
+ 
+-fms_build/libfms.a:
+-	(cd fms;tar xvf fms_env.tar)
+-	(cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared;cd shared;git checkout 34097d0)
+-	(cd fms_build;./build_fms.csh)
++fms_build/libfms.a: fms/site
++	cd fms_build;./build_fms.csh
++fms/site: | fms/fms_env.tar
++	cd fms;tar xvf fms_env.tar
++fms/shared:
++	cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared;cd shared;git checkout 34097d0
+ 
+ MOM6_ALE/build_ale/libale.a:
+ 	(cd MOM6_ALE/build_ale;./build_ale.csh)
+diff --git a/fms_build/build_fms.csh b/fms_build/build_fms.csh
+index 7b61a9b..a2c4c96 100755
+--- a/fms_build/build_fms.csh
++++ b/fms_build/build_fms.csh
+@@ -17,8 +17,8 @@ set LISTPATHS    = $root/fms/bin/list_paths
+ 
+ 
+ if ($platform == 'gfdl_hpcs') then
+-  module load netcdf/4.2
+-  module load intel_compilers
++  module load netcdf-fortran/4.5.3
++  module load intel-oneapi-compilers/2022.0.2
+ endif
+ 
+ cd $root
+diff --git a/setup.py b/setup.py
+index 231c81c..4fafb75 100644
+--- a/setup.py
++++ b/setup.py
+@@ -25,9 +25,8 @@ remap_sfc_fluxes = Extension(name = 'remap_sfc_fluxes',
+ 
+ hinterp = Extension(name = 'fms_hinterp',
+                 include_dirs = ['fms_build'],
+-                library_dirs = ['fms_build'],
++                library_dirs = ['fms_build','/app/spack/2022.01.01/linux-rhel7-x86_64/gcc-11.2.0/netcdf-fortran/4.5.3-m4arkb34bmowqtb4br3xgceig3x7tovf/lib'],
+                 libraries = ['fms','netcdf','netcdff'],
+-                extra_objects = ['fms_build/*.o'],
+                 sources = ['hinterp/hinterp.f90'])
+ 
+ 

--- a/ice_ocean_SIS2/OM4_025/preprocessing/Makefile
+++ b/ice_ocean_SIS2/OM4_025/preprocessing/Makefile
@@ -126,11 +126,12 @@ PHC2_salx.2004_08_03.nc:
 
 MIDAS:
 	git clone https://github.com/mjharriso/MIDAS.git
-	(cd MIDAS; git checkout a067a11693d97d7993c2c6522e118490666eeae0)
+	(cd MIDAS; git checkout a067a11693d97d7993c2c6522e118490666eeae0; git apply ../MIDAS.patch)
 
 local: MIDAS
 	-rm -rf $</build/*
 	mkdir -p $@
+	cd $<; make -f Makefile_GFDL fms/shared ; make -f Makefile_GFDL fms/site ; patch fms/site/gfdl_hpcs/mkmf.template ../mkmf.patch
 	cd $<; make -f Makefile_GFDL INSTALL_PATH=../local
 	touch $@
 

--- a/ice_ocean_SIS2/OM4_025/preprocessing/mkmf.patch
+++ b/ice_ocean_SIS2/OM4_025/preprocessing/mkmf.patch
@@ -1,0 +1,10 @@
+28c28
+< NETCDFPATH = /usr/local/x64/netcdf-4.2
+---
+> NETCDFPATH = `nc-config --prefix`
+32a33
+> FFLAGS += -I`nf-config --includedir`
+35c36
+< CFLAGS := -D__IFC  -fPIC -O2 -fast -I$(TOOLSHAREDIR) -I$(COREDIR) -I$(SHAREDIR) -I${NETCDFPATH}/include -I${HDF5PATH}/include 
+---
+> CFLAGS := -D__IFC  -fPIC -O2 -fast -I$(TOOLSHAREDIR) -I$(COREDIR) -I$(SHAREDIR) -I`nc-config --includedir` -I${HDF5PATH}/include 


### PR DESCRIPTION
- MIDAS environment patches for running on GFDL HPC
- Generalized NetCDF include and lib paths in mkmf.template

In addition to these patches, one must first activate a Python v2.7 environment

Closes #414 