### PR TITLE
*Update ocean_only/SCM_idealized_hurricane test case

### DIFF
--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -116,9 +116,10 @@ NK = 600                        !   [nondim]
 ! === module MOM_EOS ===
 EQN_OF_STATE = "LINEAR"         ! default = "WRIGHT"
                                 ! EQN_OF_STATE determines which ocean equation of state should be used.
-                                ! Currently, the valid choices are "LINEAR", "UNESCO", "WRIGHT", "NEMO" and
-                                ! "TEOS10". This is only used if USE_EOS is true.
-DRHO_DS = 0.0                   !   [kg m-3 PSU-1] default = 0.8
+                                ! Currently, the valid choices are "LINEAR", "UNESCO", "JACKETT_MCD", "WRIGHT",
+                                ! "WRIGHT_REDUCED", "WRIGHT_FULL", "NEMO", "ROQUET_RHO", "ROQUET_SPV" and
+                                ! "TEOS10".  This is only used if USE_EOS is true.
+DRHO_DS = 0.0                   !   [kg m-3 ppt-1] default = 0.8
                                 ! When EQN_OF_STATE=LINEAR, this is the partial derivative of density with
                                 ! salinity.
 
@@ -133,7 +134,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
                                 !  SIGMA - terrain following coordinates
                                 !  RHO   - continuous isopycnal
                                 !  HYCOM1 - HyCOM-like hybrid coordinate
-                                !  SLIGHT - stretched coordinates above continuous isopycnal
+                                !  HYBGEN - Hybrid coordinate from the Hycom hybgen code
                                 !  ADAPTIVE - optimize for smooth neutral density surfaces
 !ALE_RESOLUTION = 600*0.5       !   [m]
                                 ! The distribution of vertical resolution for the target
@@ -144,7 +145,7 @@ REGRIDDING_COORDINATE_MODE = "Z*" ! default = "LAYER"
 
 ! === module MOM_state_initialization ===
 TS_CONFIG = "SCM_CVMix_tests"   !
-                                ! A string that determines how the initial tempertures and salinities are
+                                ! A string that determines how the initial temperatures and salinities are
                                 ! specified for a new run:
                                 !     file - read velocities from the file specified
                                 !       by (TS_FILE).
@@ -165,9 +166,9 @@ TS_CONFIG = "SCM_CVMix_tests"   !
                                 !     USER - call a user modified routine.
 SCM_TEMP_MLD = 32.0             !   [m] default = 0.0
                                 ! Initial temp mixed layer depth
-SCM_L1_TEMP = 29.25             !   [C] default = 20.0
+SCM_L1_TEMP = 29.25             !   [degC] default = 20.0
                                 ! Layer 1 surface temperature
-SCM_L2_TEMP = 29.25             !   [C] default = 20.0
+SCM_L2_TEMP = 29.25             !   [degC] default = 20.0
                                 ! Layer 2 surface temperature
 SCM_L2_DTDZ = 0.04              !   [C/m] default = 0.0
                                 ! Initial temperature stratification in layer 2
@@ -178,10 +179,10 @@ SCM_L2_DTDZ = 0.04              !   [C/m] default = 0.0
 
 ! === module MOM_set_visc ===
 HBBL = 10.0                     !   [m]
-                                ! The thickness of a bottom boundary layer with a viscosity of KVBBL if
-                                ! BOTTOMDRAGLAW is not defined, or the thickness over which near-bottom
-                                ! velocities are averaged for the drag law if BOTTOMDRAGLAW is defined but
-                                ! LINEAR_DRAG is not.
+                                ! The thickness of a bottom boundary layer with a viscosity increased by
+                                ! KV_EXTRA_BBL if BOTTOMDRAGLAW is not defined, or the thickness over which
+                                ! near-bottom velocities are averaged for the drag law if BOTTOMDRAGLAW is
+                                ! defined but LINEAR_DRAG is not.
 CDRAG = 0.0                     !   [nondim] default = 0.003
                                 ! CDRAG is the drag coefficient relating the magnitude of the velocity field to
                                 ! the bottom stress. CDRAG is only used if BOTTOMDRAGLAW is defined.
@@ -202,8 +203,6 @@ KV = 1.0E-04                    !   [m2 s-1]
 
 ! === module MOM_dynamics_unsplit ===
 
-! === module MOM_continuity ===
-
 ! === module MOM_continuity_PPM ===
 UPWIND_1ST_CONTINUITY = True    !   [Boolean] default = False
                                 ! If true, CONTINUITY_PPM becomes a 1st-order upwind continuity solver.  This
@@ -215,11 +214,6 @@ ETA_TOLERANCE = 1.0E-06         !   [m] default = 3.0E-08
                                 ! total tolerance for SSH is 4 times this value.  The default is
                                 ! 0.5*NK*ANGSTROM, and this should not be set less than about
                                 ! 10^-15*MAXIMUM_DEPTH.
-ETA_TOLERANCE_AUX = 0.001       !   [m] default = 1.0E-06
-                                ! The tolerance for free-surface height discrepancies between the barotropic
-                                ! solution and the sum of the layer thicknesses when calculating the auxiliary
-                                ! corrected velocities. By default, this is the same as ETA_TOLERANCE, but can
-                                ! be made larger for efficiency.
 
 ! === module MOM_CoriolisAdv ===
 CORIOLIS_EN_DIS = True          !   [Boolean] default = False
@@ -234,7 +228,7 @@ BOUND_CORIOLIS = True           !   [Boolean] default = False
 
 ! === module MOM_PressureForce ===
 
-! === module MOM_PressureForce_AFV ===
+! === module MOM_PressureForce_FV ===
 
 ! === module MOM_hor_visc ===
 BIHARMONIC = False              !   [Boolean] default = True
@@ -268,9 +262,8 @@ USE_KPP = True                  !   [Boolean] default = False
                                 ! diffusivities and non-local transport in the OBL.
 KPP%
 APPLY_NONLOCAL_TRANSPORT = False !   [Boolean] default = True
-                                ! If True, applies the non-local transport to heat and scalars. If False,
-                                ! calculates the non-local transport and tendencies but purely for diagnostic
-                                ! purposes.
+                                ! If True, applies the non-local transport to all tracers. If False, calculates
+                                ! the non-local transport and tendencies but purely for diagnostic purposes.
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
@@ -307,17 +300,22 @@ ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
 
 ! === module MOM_surface_forcing ===
 BUOY_CONFIG = "const"           ! default = "zero"
-                                ! The character string that indicates how buoyancy forcing is specified. Valid
-                                ! options include (file), (zero), (linear), (USER), (BFB) and (NONE).
+                                ! The character string that indicates how buoyancy forcing is specified.  Valid
+                                ! options include (file), (data_override), (zero), (const), (linear), (MESO),
+                                ! (SCM_CVmix_tests), (BFB), (dumbbell), (USER) and (NONE).
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
                                 ! A constant heat forcing (positive into ocean) applied through the sensible
                                 ! heat flux field.
-WIND_CONFIG = "SCM_ideal_hurr"  ! default = "zero"
-                                ! The character string that indicates how wind forcing is specified. Valid
-                                ! options include (file), (2gyre), (1gyre), (gyres), (zero), and (USER).
+WIND_CONFIG = "ideal_hurr"      ! default = "zero"
+                                ! The character string that indicates how wind forcing is specified.  Valid
+                                ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
+                                ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
+                                ! (SCM_CVmix_tests) and (USER).
 
 ! === module idealized_hurricane ===
-IDL_HURR_SCM_BR_BENCH = True    ! default = False
+IDL_HURR_X0 = 6.48E+05          !   [m] default = 0.0
+                                ! Idealized Hurricane initial X position
+IDL_HURR_SCM_BR_BENCH = True    !   [Boolean] default = False
                                 ! Single column mode benchmark case switch, which is invoking a modification
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = True             !   [Boolean] default = False

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -1577,7 +1577,7 @@ BUOY_CONFIG = "const"           ! default = "zero"
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
                                 ! A constant heat forcing (positive into ocean) applied through the sensible
                                 ! heat flux field.
-WIND_CONFIG = "SCM_ideal_hurr"  ! default = "zero"
+WIND_CONFIG = "ideal_hurr"      ! default = "zero"
                                 ! The character string that indicates how wind forcing is specified.  Valid
                                 ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
                                 ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
@@ -1619,7 +1619,7 @@ IDL_HURR_TRAN_SPEED = 5.0       !   [m/s] default = 5.0
 IDL_HURR_TRAN_DIR = 180.0       !   [degrees] default = 180.0
                                 ! Translation direction (towards) of hurricane used in the idealized hurricane
                                 ! wind profile.
-IDL_HURR_X0 = 0.0               !   [m] default = 0.0
+IDL_HURR_X0 = 6.48E+05          !   [m] default = 0.0
                                 ! Idealized Hurricane initial X position
 IDL_HURR_Y0 = 0.0               !   [m] default = 0.0
                                 ! Idealized Hurricane initial Y position

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -303,13 +303,15 @@ BUOY_CONFIG = "const"           ! default = "zero"
 SENSIBLE_HEAT_FLUX = 0.0        !   [W/m2]
                                 ! A constant heat forcing (positive into ocean) applied through the sensible
                                 ! heat flux field.
-WIND_CONFIG = "SCM_ideal_hurr"  ! default = "zero"
+WIND_CONFIG = "ideal_hurr"      ! default = "zero"
                                 ! The character string that indicates how wind forcing is specified.  Valid
                                 ! options include (file), (data_override), (2gyre), (1gyre), (gyres), (zero),
                                 ! (const), (Neverworld), (scurves), (ideal_hurr), (SCM_ideal_hurr),
                                 ! (SCM_CVmix_tests) and (USER).
 
 ! === module idealized_hurricane ===
+IDL_HURR_X0 = 6.48E+05          !   [m] default = 0.0
+                                ! Idealized Hurricane initial X position
 IDL_HURR_SCM_BR_BENCH = True    !   [Boolean] default = False
                                 ! Single column mode benchmark case switch, which is invoking a modification
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.


### PR DESCRIPTION
  Modified the ocean_only/SCM_idealized_hurricane test case to set its wind stresses via `idealized_hurricane_wind_forcing()`, rather than the soon-to-obsoleted routine `SCM_idealized_hurricane_wind_forcing()`.  The two configurations are mathematically equivalent, but the former routine is more flexibly configurable (it is also used in the ocean_only/idealized_hurricane test case) and satisfies dimensional consistency testing.  This change is done by setting `WIND_CONFIG = "ideal_hurr"` and `IDL_HURR_X0 = 6.48e5`, which give results that differ at roundoff from the previous settings.  The regression answers will have to be updated.  The MOM_parameter_doc files have been updated to reflect this change.

  Once this update to this test case is in place, the value of "SCM_ideal_hurr" for `WIND_CONFIG` will be obsoleted and the `SCM_idealized_hurricane_wind_forcing()` routine can be removed.