### PR TITLE
Conditionally apply DAYMAX to restart runs

### DIFF
--- a/tools/MRS/setup_restart_test.sh
+++ b/tools/MRS/setup_restart_test.sh
@@ -43,6 +43,10 @@ cd 02.ignore
 test -d ../INPUT && ln -sf ../INPUT .
 cp -f ../MOM_* ../*table ../input.nml .
 test -e ../isopyc_coords.nc && cp -f ../isopyc_coords.nc .
+if [[ -z ${INPUT_DAYS} && -z ${INPUT_HOURS} ]]; then
+    sed -i "/^DAYMAX/d" MOM_input
+    echo "DAYMAX=$DOUBLE_DAYMAX" >> MOM_input
+fi
 sed -i "/^DAYMAX/d" MOM_input; echo "DAYMAX=$DOUBLE_DAYMAX" >> MOM_input
 sed -i "/^TIMEUNIT/d" MOM_input; echo TIMEUNIT=1. >> MOM_input
 sed -i "/^ENERGYSAVEDAYS/d" MOM_input; echo "ENERGYSAVEDAYS=$DT" >> MOM_input
@@ -57,7 +61,10 @@ cd ../01.ignore
 test -d ../INPUT && ln -sf ../INPUT .
 cp -f ../MOM_* ../*table ../input.nml .
 test -e ../isopyc_coords.nc && cp -f ../isopyc_coords.nc .
-sed -i "/^DAYMAX/d" MOM_input; echo "DAYMAX=$HALF_DAYMAX" >> MOM_input
+if [[ -z ${INPUT_DAYS} && -z ${INPUT_HOURS} ]]; then
+    sed -i "/^DAYMAX/d" MOM_input
+    echo "DAYMAX=$DOUBLE_DAYMAX" >> MOM_input
+fi
 sed -i "/^TIMEUNIT/d" MOM_input; echo TIMEUNIT=1. >> MOM_input
 sed -i "/^ENERGYSAVEDAYS/d" MOM_input; echo "ENERGYSAVEDAYS=$DT" >> MOM_input
 sed -i "/^RESTART_CONTROL/d" MOM_input; echo "RESTART_CONTROL=1" >> MOM_input
@@ -72,7 +79,10 @@ cd ../12.ignore
 test -d ../INPUT && mkdir -p INPUT && ( cd INPUT && ln -sf ../../INPUT/* . )
 cp -f ../MOM_* ../*table ../input.nml .
 test -e ../isopyc_coords.nc && cp -f ../isopyc_coords.nc .
-sed -i "/^DAYMAX/d" MOM_input; echo "DAYMAX=$DOUBLE_DAYMAX" >> MOM_input
+if [[ -z ${INPUT_DAYS} && -z ${INPUT_HOURS} ]]; then
+    sed -i "/^DAYMAX/d" MOM_input
+    echo "DAYMAX=$DOUBLE_DAYMAX" >> MOM_input
+fi
 sed -i "/^TIMEUNIT/d" MOM_input; echo TIMEUNIT=1. >> MOM_input
 sed -i "/^ENERGYSAVEDAYS/d" MOM_input; echo "ENERGYSAVEDAYS=$DT" >> MOM_input
 [[ ! -z $INPUT_DAYS ]] && sed -i "/days/c days=$HALF_DAYS," input.nml


### PR DESCRIPTION
MRS restart testing is modified to only append DAYMAX to MOM_input if the test does not use input.nml.  If the input uses input.nml to set runtime, then DAYMAX is not used.

This prevents errors for runs using FATAL_UNUSED_PARAMS.