### PR TITLE
Fix premature FMS lib tests in coupled models

### DIFF
--- a/coupled_AM2_LM3_SIS2/configure.coupled.ac
+++ b/coupled_AM2_LM3_SIS2/configure.coupled.ac
@@ -78,14 +78,6 @@ AS_IF([test "x$with_driver" != "x"],
   [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}])
 
 
-# Determine the FMS IO implementation.
-AX_FC_CHECK_MODULE([fms2_io_mod], [
-  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
-],[
-  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1
-])
-
-
 # Explicitly assume free-form Fortran
 AC_LANG([Fortran])
 AC_FC_SRCEXT([f90])
@@ -237,6 +229,14 @@ AC_COMPILE_IFELSE(
     AC_MSG_ERROR([diag_axis_mod in MOM6 requires FMS 2019.01.02 or newer.])
   ]
 )
+
+
+# Determine the FMS IO implementation.
+AX_FC_CHECK_MODULE([fms2_io_mod], [
+  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
+],[
+  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1
+])
 
 
 # Verify that Python is available

--- a/ice_ocean_SIS2/configure.ice_ocean.ac
+++ b/ice_ocean_SIS2/configure.ice_ocean.ac
@@ -78,14 +78,6 @@ AS_IF([test "x$with_driver" != "x"],
   [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}])
 
 
-# Determine the FMS IO implementation.
-AX_FC_CHECK_MODULE([fms2_io_mod], [
-  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS2
-],[
-  MODEL_FRAMEWORK=${srcdir}/config_src/infra/FMS1
-])
-
-
 # Explicitly assume free-form Fortran
 AC_LANG([Fortran])
 AC_FC_SRCEXT([f90])


### PR DESCRIPTION
The FMS infra test was incorrectly set before the Fortran compiler is declared, and before any FMS library tests.  This caused the test to run with a C compiler, and before the library had even been verified to exist.

The ice-ocean model ran this macro before and after the FMS testing.  It seems to have covered up the incorrect macro.

The AM2-coupled model only ran this macro before Fortran and FMS setup. It never correctly tested its FMS infra, and errors could follow.

This patch cleans up the tests so that each model runs the macro after FMS macro testing.