### PR TITLE
Fix re-compilation on dependency changes in Makefiles

### DIFF
--- a/ice_ocean_SIS2/Makefile
+++ b/ice_ocean_SIS2/Makefile
@@ -125,8 +125,8 @@ $(BUILD)/config.status: $(ICEBERGS_BUILD)/libicebergs.a
 $(BUILD)/config.status: $(BUILD)/configure
 	cd $(BUILD) && \
 	PATH="${PATH}:$(dir $(abspath $(MAKEDEP)))" \
-	FCFLAGS="${MOM_FCFLAGS}" \
-	LDFLAGS="${MOM_LDFLAGS}" \
+	FCFLAGS="$(MOM_FCFLAGS)" \
+	LDFLAGS="$(MOM_LDFLAGS)" \
 	./configure -n $(CONFIG_FLAGS)
 
 $(BUILD)/Makefile.in: $(MAKEFILE_IN) | $(BUILD)
@@ -154,25 +154,25 @@ $(ATMOS_BUILD)/libatmos_null.a: $(FMS_BUILD)/libFMS.a
 	  BUILD=$(abspath $(ATMOS_BUILD)) \
 	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
-$(LAND_BUILD)/libland_null.a: $(wildcard,../src/land_null/*)
+$(LAND_BUILD)/libland_null.a: $(wildcard ../src/land_null/*)
 $(LAND_BUILD)/libland_null.a: $(FMS_BUILD)/libFMS.a
 	$(MAKE) -C ../shared/land_null \
 	  BUILD=$(abspath $(LAND_BUILD)) \
 	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
-$(ICE_PARAM_BUILD)/libice_param.a: $(wildcard,../src/ice_param/*)
+$(ICE_PARAM_BUILD)/libice_param.a: $(wildcard ../src/ice_param/*)
 $(ICE_PARAM_BUILD)/libice_param.a: $(FMS_BUILD)/libFMS.a
 	$(MAKE) -C ../shared/ice_param \
 	  BUILD=$(abspath $(ICE_PARAM_BUILD)) \
 	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
-$(ICEBERGS_BUILD)/libicebergs.a: $(wildcard,../src/icebergs/src/*)
+$(ICEBERGS_BUILD)/libicebergs.a: $(wildcard ../src/icebergs/src/*)
 $(ICEBERGS_BUILD)/libicebergs.a: $(FMS_BUILD)/libFMS.a
 	$(MAKE) -C ../shared/icebergs \
 	  BUILD=$(abspath $(ICEBERGS_BUILD)) \
 	  FMS_BUILD=$(abspath $(FMS_BUILD))
 
-$(FMS_BUILD)/libFMS.a: $(wildcard,$(FMS_CODEBASE)/*/*)
+$(FMS_BUILD)/libFMS.a: $(wildcard $(FMS_CODEBASE)/*/*)
 	$(MAKE) -C ../shared/fms \
 	  BUILD=$(abspath $(FMS_BUILD)) \
 	  CODEBASE=$(abspath $(FMS_CODEBASE))

--- a/shared/AM2/Makefile
+++ b/shared/AM2/Makefile
@@ -20,6 +20,9 @@ LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
 
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)
+
 #----
 # External Codebase
 # NOTE: These are only visible within the GFDL firewall

--- a/shared/LM3/Makefile
+++ b/shared/LM3/Makefile
@@ -14,6 +14,9 @@ LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
 
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)
+
 #----
 # External Codebase
 # NOTE: These are only visible within the GFDL firewall

--- a/shared/atmos_null/Makefile
+++ b/shared/atmos_null/Makefile
@@ -10,3 +10,6 @@ FCFLAGS += -I$(abspath $(FMS_BUILD))
 LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
+
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)

--- a/shared/config/Libs.mk
+++ b/shared/config/Libs.mk
@@ -10,6 +10,7 @@ MAKEPATH = $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 M4DIR ?= $(MAKEPATH)/../../src/MOM6/ac/m4
 MAKEDEP = $(MAKEPATH)/../../src/MOM6/ac/makedep
 
+
 # `export` disables autoconf defaults; this restores them
 CFLAGS ?= -g -O2
 FCFLAGS ?= -g -O2
@@ -39,9 +40,6 @@ MAKEFLAGS += -rR
 
 all: $(BUILD)/$(TARGET)
 
-$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call rwildcard,$(CODEBASE),*.h *.c *.inc *.F90)
-	$(MAKE) -C $(BUILD) $(TARGET)
-
 FORCE:
 
 $(BUILD)/Makefile: $(BUILD)/Makefile.in $(BUILD)/configure
@@ -66,6 +64,7 @@ $(BUILD):
 
 # Recursive wildcard (finds all files in $1 with suffixes in $2)
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+find_src_files=$(call rwildcard,$1,*.h *.c *.inc *.f90 *.F90)
 
 .PHONY: clean
 clean:

--- a/shared/config/Makefile.in
+++ b/shared/config/Makefile.in
@@ -32,4 +32,4 @@ SRCDIRS = @SRCDIRS@
 .PHONY: depend
 depend: Makefile.dep
 Makefile.dep:
-	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e -x $(LIBTARGET) $(SRCDIRS)
+	$(PYTHON) $(MAKEDEP) $(DEFS) -o Makefile.dep -e -x $(LIBTARGET) $(CPPFLAGS) $(SRCDIRS)

--- a/shared/fms/Makefile
+++ b/shared/fms/Makefile
@@ -12,3 +12,6 @@ CPPFLAGS += -DAU_TEST_KIND_=r8_kind
 CPPFLAGS += -DTEST_SVP_KIND_=8
 
 include ../config/Libs.mk
+
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)

--- a/shared/ice_param/Makefile
+++ b/shared/ice_param/Makefile
@@ -10,3 +10,6 @@ FCFLAGS += -I$(abspath $(FMS_BUILD))
 LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
+
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)

--- a/shared/icebergs/Makefile
+++ b/shared/icebergs/Makefile
@@ -10,3 +10,6 @@ FCFLAGS += -I$(abspath $(FMS_BUILD))
 LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
+
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)

--- a/shared/land_null/Makefile
+++ b/shared/land_null/Makefile
@@ -10,3 +10,6 @@ FCFLAGS += -I$(abspath $(FMS_BUILD))
 LDFLAGS += -L$(abspath $(FMS_BUILD))
 
 include ../config/Libs.mk
+
+$(BUILD)/$(TARGET): $(BUILD)/Makefile $(call find_src_files,$(CODEBASE))
+	$(MAKE) -C $(BUILD) $(TARGET)


### PR DESCRIPTION
- Replaced ${ } with $( ) in ice_ocean_SIS2/Makefile (typo)
- Fixed syntax for an invocation $(wildcard ...) which incorrectly had  ","
- Moved $(BUILD)/$(TARGET): recipe upward out of config/Libs.mk to allow dependency state detection. For some reason we cannot find documentation on, the dependencies resulting from a macro (function) were not evaluated when inside an included file. :(

Todo:
- Have icebergs/Makefile detect which FMS is being used
- List sub-directories full/ and shared/ within coupler/. Newer versions of the coupler have multiple versions of some files which causes conflicts for makedep.