### PR TITLE
Patch for newer FMS2 directory structure

### DIFF
--- a/coupled_AM2_LM3_SIS2/Makefile
+++ b/coupled_AM2_LM3_SIS2/Makefile
@@ -285,7 +285,9 @@ $(TESTDIR)/%/test: $(BUILD)/coupler_main
 #----
 # Cleanup
 
-.PHONY: clean
+.PHONY: clean clean.fms
+clean.fms: clean
+	$(MAKE) -C ../shared/fms BUILD=$(abspath $(FMS_BUILD)) clean
 clean:
 	$(MAKE) -C ../shared/AM2 BUILD=$(abspath $(AM2_BUILD)) clean
 	$(MAKE) -C ../shared/LM3 BUILD=$(abspath $(LM3_BUILD)) clean

--- a/ice_ocean_SIS2/Makefile
+++ b/ice_ocean_SIS2/Makefile
@@ -39,7 +39,11 @@ EXCLUDE ?= \
 EXTRA_SRC_DIRS := \
   $(abspath ../src/SIS2/src) \
   $(abspath ../src/SIS2/config_src/external) \
-  $(abspath ../src/coupler)
+  $(abspath $(dir $(wildcard ../src/coupler/full/ice_ocean_flux_exchange.F90)) \
+            $(dir $(wildcard ../src/coupler/shared/surface_flux.F90)) \
+            $(dir $(wildcard ../src/coupler/surface_flux.F90)) )
+# The above $(or ...) covers the transition from FMS1-era to FMS2-era versions
+# of the coupler. The latter has multiple versions of the main coupler.
 
 CONFIG_FLAGS := --config-cache
 CONFIG_FLAGS += --srcdir=$(abspath $(MOM_CODEBASE))
@@ -281,7 +285,9 @@ $(TESTDIR)/%/test: $(BUILD)/coupler_main
 #----
 # Cleanup
 
-.PHONY: clean
+.PHONY: clean clean.fms
+clean.fms: clean
+	$(MAKE) -C ../shared/fms BUILD=$(abspath $(FMS_BUILD)) clean
 clean:
 	$(MAKE) -C ../shared/atmos_null BUILD=$(abspath $(ATMOS_BUILD)) clean
 	$(MAKE) -C ../shared/land_null BUILD=$(abspath $(LAND_BUILD)) clean

--- a/ocean_only/Makefile
+++ b/ocean_only/Makefile
@@ -265,7 +265,9 @@ $(TESTDIR)/%/test: $(BUILD)/MOM6
 # Cleanup
 
 # I probably need a rule in Makefile.in for all the autoconf stuff.
-.PHONY: clean
+.PHONY: clean clean.fms
+clean.fms: clean
+	$(MAKE) -C ../shared/fms BUILD=$(abspath $(FMS_BUILD)) clean
 clean:
 	rm -rf $(BUILD)
 


### PR DESCRIPTION
- Uses `$(or )` macro to accommodate change in file locations
- Added "full-clean" targets to clean FMS objects in addition to "clean"