### PR TITLE
Explicitly define external directory of SIS2

### DIFF
--- a/coupled_AM2_LM3_SIS2/Makefile
+++ b/coupled_AM2_LM3_SIS2/Makefile
@@ -37,7 +37,7 @@ EXCLUDE ?= \
 # Autoconf setup
 EXTRA_SRC_DIRS = \
   $(abspath ../src/SIS2/src) \
-  $(abspath ../src/SIS2/config_src/external) \
+  $(abspath ../src/SIS2/config_src/external/Icepack_interfaces) \
   $(abspath ../src/coupler)
 
 CONFIG_FLAGS := --config-cache

--- a/ice_ocean_SIS2/Makefile
+++ b/ice_ocean_SIS2/Makefile
@@ -38,7 +38,7 @@ EXCLUDE ?= \
 # Autoconf setup
 EXTRA_SRC_DIRS := \
   $(abspath ../src/SIS2/src) \
-  $(abspath ../src/SIS2/config_src/external) \
+  $(abspath ../src/SIS2/config_src/external/Icepack_interfaces) \
   $(abspath ../src/coupler)
 
 CONFIG_FLAGS := --config-cache

--- a/tools/MRS/Makefile.build
+++ b/tools/MRS/Makefile.build
@@ -186,10 +186,30 @@ $(eval $(call compile,,MOM6,$$(ENV_SCRIPT),))
 # Generate lists of variables and dependencies for SIS2 libraries
 # $(1) = compiler, $(2) = mode, $(3) = memory style, $(4) = mom6 configuration
 define sis2-variables
-$(BUILD)/$(1)/$(2)/dynamic_nonsymmetric/$(4)/path_names: $(SIS2_SRC)/config_src/dynamic/* $(SIS2_SRC)/config_src/external/* $(SIS2_SRC)/src/* $(MOM6_SRC)/src/framework/MOM_memory_macros.h
-$(BUILD)/$(1)/$(2)/dynamic_nonsymmetric/$(4)/path_names: LIST_PATHS_ARGS =  $(SIS2_SRC)/config_src/dynamic/ $(SIS2_SRC)/config_src/external/* $(SIS2_SRC)/src/ $(MOM6_SRC)/src/framework/MOM_memory_macros.h
-$(BUILD)/$(1)/$(2)/dynamic_symmetric/$(4)/path_names: $(SIS2_SRC)/config_src/dynamic_symmetric/* $(SIS2_SRC)/config_src/external/* $(SIS2_SRC)/src/* $(MOM6_SRC)/src/framework/MOM_memory_macros.h
-$(BUILD)/$(1)/$(2)/dynamic_symmetric/$(4)/path_names: LIST_PATHS_ARGS =  $(SIS2_SRC)/config_src/dynamic_symmetric/ $(SIS2_SRC)/config_src/external/* $(SIS2_SRC)/src/ $(MOM6_SRC)/src/framework/MOM_memory_macros.h
+$(BUILD)/$(1)/$(2)/dynamic_nonsymmetric/$(4)/path_names: \
+  $(SIS2_SRC)/config_src/dynamic/* \
+  $(SIS2_SRC)/config_src/external/Icepack_interfaces/* \
+  $(SIS2_SRC)/src/* \
+  $(MOM6_SRC)/src/framework/MOM_memory_macros.h
+
+$(BUILD)/$(1)/$(2)/dynamic_nonsymmetric/$(4)/path_names: \
+  LIST_PATHS_ARGS = $(SIS2_SRC)/config_src/dynamic/ \
+  $(SIS2_SRC)/config_src/external/Icepack_interfaces/ \
+  $(SIS2_SRC)/src/ \
+  $(MOM6_SRC)/src/framework/MOM_memory_macros.h
+
+$(BUILD)/$(1)/$(2)/dynamic_symmetric/$(4)/path_names: \
+  $(SIS2_SRC)/config_src/dynamic_symmetric/* \
+  $(SIS2_SRC)/config_src/external/Icepack_interfaces/* \
+  $(SIS2_SRC)/src/* \
+  $(MOM6_SRC)/src/framework/MOM_memory_macros.h
+
+$(BUILD)/$(1)/$(2)/dynamic_symmetric/$(4)/path_names: \
+  LIST_PATHS_ARGS = $(SIS2_SRC)/config_src/dynamic_symmetric/ \
+  $(SIS2_SRC)/config_src/external/Icepack_interfaces/ \
+  $(SIS2_SRC)/src/ \
+  $(MOM6_SRC)/src/framework/MOM_memory_macros.h
+
 $(BUILD)/$(1)/$(2)/$(3)/$(4)/Makefile: CPP_DEFS = -D_FILE_VERSION="`$(GIT_VERSION_SCRIPT) $$$$<`" -DSTATSLABEL=\"$(STATS_PLATFORM)$(1)$(STATS_COMPILER_VER)\"
 $(BUILD)/$(1)/$(2)/$(3)/$(4)/libsis2.a: $(BUILD)/$(1)/$(2)/icebergs/libicebergs.a $(BUILD)/$(1)/$(2)/ice_param/libice_param.a
 .SECONDARY: $(BUILD)/$(1)/$(2)/$(3)/$(4)/path_names


### PR DESCRIPTION
The imminent introduction of the icebergs stub to SIS2, which is not used in our CI tests, can override the libicebergs.a symbols, causing the latter to never be used.  This can change answers (among other things).

The glob `external/*` mkmf pathing is replaced with `external/Icepack_interfaces`, so that any future icebergs stub will be ignored.