### PR TITLE
MOM6: ac: Conditional testing of GSW and CVMix libs

### DIFF
--- a/coupled_AM2_LM3_SIS2/configure.coupled.ac
+++ b/coupled_AM2_LM3_SIS2/configure.coupled.ac
@@ -1,4 +1,5 @@
 # Autoconf configuration
+
 AC_PREREQ([2.63])
 
 AC_INIT(
@@ -27,7 +28,7 @@ AS_VAR_IF([MOM_MEMORY], [],
 )
 
 # Confirm that MOM_MEMORY is named 'MOM_memory.h'
-AS_IF([test $(basename "${MOM_MEMORY}") == "MOM_memory.h"], [],
+AS_IF([test $(basename "${MOM_MEMORY}") = "MOM_memory.h"], [],
  [AC_MSG_ERROR([MOM_MEMORY header ${MOM_MEMORY} must be named 'MOM_memory.h'])]
 )
 
@@ -74,8 +75,24 @@ AC_ARG_WITH([driver],
     [Select directory for driver source code]
   )
 )
-AS_IF([test "x$with_driver" != "x"],
-  [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}])
+AS_IF([test -n "$with_driver"],
+  [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}]
+)
+
+# External library configuration
+AC_ARG_WITH([gsw],
+  [AS_HELP_STRING(
+    [--with-gsw],
+    [use external Gibbs Sea Water library instead of linked source]
+  )], [], [with_gsw=no]
+)
+
+AC_ARG_WITH([cvmix],
+  [AS_HELP_STRING(
+    [--with-cvmix],
+    [use external CVMix library instead of linked source]
+  )], [], [with_cvmix=no]
+)
 
 
 # Explicitly assume free-form Fortran
@@ -136,31 +153,37 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 ])
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
-# NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
-#     not currently probe the Fortran 90 interfaces.
-#   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+# NOTE: nf-config does not have --libdir, so we parse the --flibs output.
+MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf90_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
 AX_FC_REAL8
 AS_IF(
   [test "$enable_real8" != no],
-  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"])
+  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"]
+)
 
 
 # Unlimited line length (2.67)
@@ -198,22 +221,24 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
   AX_FC_CHECK_MODULE([fms_mod],
     [AC_SUBST([FCFLAGS], ["-I${srcdir}/ac/deps/include $FCFLAGS"])],
     [AC_MSG_ERROR([Could not find fms_mod Fortran module.])],
-    [-I${srcdir}/ac/deps/include])
+    [-I${srcdir}/ac/deps/include]
+  )
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
-
 
 # Verify that FMS is at least 2019.01.02
 # NOTE: 2019.01.02 introduced two changes:
@@ -239,29 +264,76 @@ AX_FC_CHECK_MODULE([fms2_io_mod], [
 ])
 
 
-# Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
-  AC_MSG_ERROR([Could not find python.])
+# GSW configuration
+AS_IF([test "$with_gsw" = yes], [
+  AX_FC_CHECK_MODULE([gsw_mod_toolbox], [], [
+    AC_MSG_ERROR([Could not find module gsw_mod_toolbox.])
+  ])
+  MOM6_FC_CHECK_LIB([gsw], [gsw_rho], [gsw_mod_toolbox], [sa,ct,p], [rho], [],
+    [], [
+      AC_MSG_ERROR([Could not find gsw_rho in gsw_mod_toolbox.])
+    ]
+  )
 ])
+
+
+# CVMix configuration
+AS_IF([test "$with_cvmix" = yes], [
+  AX_FC_CHECK_MODULE([cvmix_kpp], [], [
+    AC_MSG_ERROR([Could not find module cvmix_kpp.])
+  ])
+  MOM6_FC_CHECK_LIB([cvmix], [cvmix_init_kpp], [cvmix_kpp], [], [], [],
+    [], [
+      AC_MSG_ERROR([Could not find cvmix_init_kpp in cvmix_kpp.])
+    ]
+  )
+])
+
+
+# Python configuration
+
+# Declare the Python interpreter variable
 AC_ARG_VAR([PYTHON], [Python interpreter command])
 
+# If PYTHON is set to an empty string, then unset it
+AS_VAR_IF([PYTHON], [], [AS_UNSET([PYTHON])], [])
 
-# Verify that makedep is available
+# Now attempt to find a Python interpreter if PYTHON is unset
+AS_VAR_SET_IF([PYTHON], [
+  AC_PATH_PROGS([PYTHON], ["$PYTHON"], [none])
+], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2], [none])
+])
+AS_VAR_IF([PYTHON], [none], [
+  AC_MSG_ERROR([Python interpreter not found.])
+])
+
+
+# Makedep configuration
 AC_PATH_PROG([MAKEDEP], [makedep], [${srcdir}/ac/makedep])
 AC_SUBST([MAKEDEP])
 
+# Generate Makedep source list and configure dependency command
+MAKEDEP_FLAGS="-e"
 
-# Generate source list and configure dependency command
-AC_SUBST([SRC_DIRS], ["\\
+# Exclude linked source files from makedep search
+AS_IF([test "$with_gsw" = yes], [
+  MAKEDEP_FLAGS="${MAKEDEP_FLAGS} \\
+    -s ${srcdir}/src/equation_of_state/TEOS10"
+])
+
+AS_IF([test "$with_cvmix" = yes], [
+  MAKEDEP_FLAGS="${MAKEDEP_FLAGS} \\
+    -s ${srcdir}/src/parameterizations/CVmix"
+])
+
+SRC_DIRS="\\
   ${srcdir}/src \\
   ${MODEL_FRAMEWORK} \\
   ${srcdir}/config_src/external \\
   ${DRIVER_DIR} \\
   ${MOM_MEMORY_DIR} \\
   ${SIS_MEMORY_DIR}"
-])
-AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
-
 
 # Append user-defined source directories
 AC_ARG_VAR([EXTRA_SRC_DIRS], [Additional source code to include in build])
@@ -269,15 +341,35 @@ AS_IF([test -n "${EXTRA_SRC_DIRS}"], [
   SRC_DIRS="${SRC_DIRS} ${EXTRA_SRC_DIRS}"
 ])
 
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${SRC_DIRS}"
+
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
+AC_SUBST([MAKEDEP_FLAGS])
+
+# Add makedep to config.status
+AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
+
 
 # POSIX verification tests
 
-# These symbols may be defined as macros, making them inaccessible by Fortran.
-# These three exist in modern BSD and Linux libc, so we just confirm them.
-# But one day, we many need to handle them more carefully.
-AX_FC_CHECK_BIND_C([setjmp], [], [AC_MSG_ERROR([Could not find setjmp.])])
-AX_FC_CHECK_BIND_C([longjmp], [], [AC_MSG_ERROR([Could not find longjmp.])])
-AX_FC_CHECK_BIND_C([siglongjmp], [], [AC_MSG_ERROR([Could not find siglongjmp.])])
+# Symbols in <setjmp.h> may be defined as macros, making them inaccessible by
+# Fortran C bindings.  `sigsetjmp` is known to have an internal symbol in
+# glibc, so we check for this possibility.  For the others, we only check for
+# existence.
+
+# If the need arises, we may want to define these under a standalone macro.
+
+# Validate the setjmp symbol
+AX_FC_CHECK_BIND_C([setjmp],
+  [SETJMP="setjmp"], [SETJMP="setjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SETJMP_NAME], ["${SETJMP}"])
+
+# Validate the longjmp symbol
+AX_FC_CHECK_BIND_C([longjmp],
+  [LONGJMP="longjmp"], [LONGJMP="longjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([LONGJMP_NAME], ["${LONGJMP}"])
 
 # Determine the sigsetjmp symbol.  If missing, then point to sigsetjmp_missing.
 #
@@ -292,6 +384,13 @@ for sigsetjmp_fn in sigsetjmp __sigsetjmp; do
   ])
 done
 AC_DEFINE_UNQUOTED([SIGSETJMP_NAME], ["${SIGSETJMP}"])
+
+# Validate the siglongjmp symbol
+AX_FC_CHECK_BIND_C([siglongjmp],
+  [SIGLONGJMP="siglongjmp"], [SIGLONGJMP="siglongjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SIGLONGJMP_NAME], ["${SIGLONGJMP}"])
+
 
 # Verify the size of nonlocal jump buffer structs
 # NOTE: This requires C compiler, but can it be done with a Fortran compiler?

--- a/ice_ocean_SIS2/configure.ice_ocean.ac
+++ b/ice_ocean_SIS2/configure.ice_ocean.ac
@@ -1,4 +1,5 @@
 # Autoconf configuration
+
 AC_PREREQ([2.63])
 
 AC_INIT(
@@ -27,7 +28,7 @@ AS_VAR_IF([MOM_MEMORY], [],
 )
 
 # Confirm that MOM_MEMORY is named 'MOM_memory.h'
-AS_IF([test $(basename "${MOM_MEMORY}") == "MOM_memory.h"], [],
+AS_IF([test $(basename "${MOM_MEMORY}") = "MOM_memory.h"], [],
  [AC_MSG_ERROR([MOM_MEMORY header ${MOM_MEMORY} must be named 'MOM_memory.h'])]
 )
 
@@ -74,8 +75,24 @@ AC_ARG_WITH([driver],
     [Select directory for driver source code]
   )
 )
-AS_IF([test "x$with_driver" != "x"],
-  [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}])
+AS_IF([test -n "$with_driver"],
+  [DRIVER_DIR=${srcdir}/config_src/drivers/${with_driver}]
+)
+
+# External library configuration
+AC_ARG_WITH([gsw],
+  [AS_HELP_STRING(
+    [--with-gsw],
+    [use external Gibbs Sea Water library instead of linked source]
+  )], [], [with_gsw=no]
+)
+
+AC_ARG_WITH([cvmix],
+  [AS_HELP_STRING(
+    [--with-cvmix],
+    [use external CVMix library instead of linked source]
+  )], [], [with_cvmix=no]
+)
 
 
 # Explicitly assume free-form Fortran
@@ -136,31 +153,37 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 ])
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
-# NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
-#     not currently probe the Fortran 90 interfaces.
-#   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+# NOTE: nf-config does not have --libdir, so we parse the --flibs output.
+MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf90_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf90_create], [netcdf], [path,cmode,ncid], [rc], [
+        character :: path
+        integer :: cmode, ncid, rc],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
 AX_FC_REAL8
 AS_IF(
   [test "$enable_real8" != no],
-  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"])
+  [FCFLAGS="$FCFLAGS $REAL8_FCFLAGS"]
+)
 
 
 # Unlimited line length (2.67)
@@ -198,22 +221,24 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
   AX_FC_CHECK_MODULE([fms_mod],
     [AC_SUBST([FCFLAGS], ["-I${srcdir}/ac/deps/include $FCFLAGS"])],
     [AC_MSG_ERROR([Could not find fms_mod Fortran module.])],
-    [-I${srcdir}/ac/deps/include])
+    [-I${srcdir}/ac/deps/include]
+  )
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
-
 
 # Verify that FMS is at least 2019.01.02
 # NOTE: 2019.01.02 introduced two changes:
@@ -239,29 +264,76 @@ AX_FC_CHECK_MODULE([fms2_io_mod], [
 ])
 
 
-# Verify that Python is available
-AC_PATH_PROGS([PYTHON], [python python3 python2], [
-  AC_MSG_ERROR([Could not find python.])
+# GSW configuration
+AS_IF([test "$with_gsw" = yes], [
+  AX_FC_CHECK_MODULE([gsw_mod_toolbox], [], [
+    AC_MSG_ERROR([Could not find module gsw_mod_toolbox.])
+  ])
+  MOM6_FC_CHECK_LIB([gsw], [gsw_rho], [gsw_mod_toolbox], [sa,ct,p], [rho], [],
+    [], [
+      AC_MSG_ERROR([Could not find gsw_rho in gsw_mod_toolbox.])
+    ]
+  )
 ])
+
+
+# CVMix configuration
+AS_IF([test "$with_cvmix" = yes], [
+  AX_FC_CHECK_MODULE([cvmix_kpp], [], [
+    AC_MSG_ERROR([Could not find module cvmix_kpp.])
+  ])
+  MOM6_FC_CHECK_LIB([cvmix], [cvmix_init_kpp], [cvmix_kpp], [], [], [],
+    [], [
+      AC_MSG_ERROR([Could not find cvmix_init_kpp in cvmix_kpp.])
+    ]
+  )
+])
+
+
+# Python configuration
+
+# Declare the Python interpreter variable
 AC_ARG_VAR([PYTHON], [Python interpreter command])
 
+# If PYTHON is set to an empty string, then unset it
+AS_VAR_IF([PYTHON], [], [AS_UNSET([PYTHON])], [])
 
-# Verify that makedep is available
+# Now attempt to find a Python interpreter if PYTHON is unset
+AS_VAR_SET_IF([PYTHON], [
+  AC_PATH_PROGS([PYTHON], ["$PYTHON"], [none])
+], [
+  AC_PATH_PROGS([PYTHON], [python python3 python2], [none])
+])
+AS_VAR_IF([PYTHON], [none], [
+  AC_MSG_ERROR([Python interpreter not found.])
+])
+
+
+# Makedep configuration
 AC_PATH_PROG([MAKEDEP], [makedep], [${srcdir}/ac/makedep])
 AC_SUBST([MAKEDEP])
 
+# Generate Makedep source list and configure dependency command
+MAKEDEP_FLAGS="-e"
 
-# Generate source list and configure dependency command
-AC_SUBST([SRC_DIRS], ["\\
+# Exclude linked source files from makedep search
+AS_IF([test "$with_gsw" = yes], [
+  MAKEDEP_FLAGS="${MAKEDEP_FLAGS} \\
+    -s ${srcdir}/src/equation_of_state/TEOS10"
+])
+
+AS_IF([test "$with_cvmix" = yes], [
+  MAKEDEP_FLAGS="${MAKEDEP_FLAGS} \\
+    -s ${srcdir}/src/parameterizations/CVmix"
+])
+
+SRC_DIRS="\\
   ${srcdir}/src \\
   ${MODEL_FRAMEWORK} \\
   ${srcdir}/config_src/external \\
   ${DRIVER_DIR} \\
   ${MOM_MEMORY_DIR} \\
   ${SIS_MEMORY_DIR}"
-])
-AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
-
 
 # Append user-defined source directories
 AC_ARG_VAR([EXTRA_SRC_DIRS], [Additional source code to include in build])
@@ -269,15 +341,35 @@ AS_IF([test -n "${EXTRA_SRC_DIRS}"], [
   SRC_DIRS="${SRC_DIRS} ${EXTRA_SRC_DIRS}"
 ])
 
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${SRC_DIRS}"
+
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
+AC_SUBST([MAKEDEP_FLAGS])
+
+# Add makedep to config.status
+AC_CONFIG_COMMANDS(Makefile.dep, [make depend])
+
 
 # POSIX verification tests
 
-# These symbols may be defined as macros, making them inaccessible by Fortran.
-# These three exist in modern BSD and Linux libc, so we just confirm them.
-# But one day, we many need to handle them more carefully.
-AX_FC_CHECK_BIND_C([setjmp], [], [AC_MSG_ERROR([Could not find setjmp.])])
-AX_FC_CHECK_BIND_C([longjmp], [], [AC_MSG_ERROR([Could not find longjmp.])])
-AX_FC_CHECK_BIND_C([siglongjmp], [], [AC_MSG_ERROR([Could not find siglongjmp.])])
+# Symbols in <setjmp.h> may be defined as macros, making them inaccessible by
+# Fortran C bindings.  `sigsetjmp` is known to have an internal symbol in
+# glibc, so we check for this possibility.  For the others, we only check for
+# existence.
+
+# If the need arises, we may want to define these under a standalone macro.
+
+# Validate the setjmp symbol
+AX_FC_CHECK_BIND_C([setjmp],
+  [SETJMP="setjmp"], [SETJMP="setjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SETJMP_NAME], ["${SETJMP}"])
+
+# Validate the longjmp symbol
+AX_FC_CHECK_BIND_C([longjmp],
+  [LONGJMP="longjmp"], [LONGJMP="longjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([LONGJMP_NAME], ["${LONGJMP}"])
 
 # Determine the sigsetjmp symbol.  If missing, then point to sigsetjmp_missing.
 #
@@ -292,6 +384,13 @@ for sigsetjmp_fn in sigsetjmp __sigsetjmp; do
   ])
 done
 AC_DEFINE_UNQUOTED([SIGSETJMP_NAME], ["${SIGSETJMP}"])
+
+# Validate the siglongjmp symbol
+AX_FC_CHECK_BIND_C([siglongjmp],
+  [SIGLONGJMP="siglongjmp"], [SIGLONGJMP="siglongjmp_missing"]
+)
+AC_DEFINE_UNQUOTED([SIGLONGJMP_NAME], ["${SIGLONGJMP}"])
+
 
 # Verify the size of nonlocal jump buffer structs
 # NOTE: This requires C compiler, but can it be done with a Fortran compiler?

--- a/ocean_only/Makefile
+++ b/ocean_only/Makefile
@@ -73,7 +73,7 @@ EXCLUDE ?= \
 
 # Autoconf setup
 CONFIG_FLAGS := --config-cache
-CONFIG_FLAGS += --srcdir=$(abspath $(CODEBASE))/ac
+CONFIG_FLAGS += --srcdir=$(abspath $(CODEBASE))
 ifdef MOM_MEMORY
   CONFIG_FLAGS += MOM_MEMORY=$(abspath $(MOM_MEMORY))
 endif


### PR DESCRIPTION
The ice-ocean and coupled-AM2 configure.ac files are updated for compatibility to the most recent changes to makedep and `Makefile.in`.

The ocean-only Makefile is updated to point the MOM6 srcdir to the top directory, rather than the internal `ac/` directory.

- NOAA-GFDL/MOM6@240775c8f ac: Conditional testing of GSW and CVMix libs
- NOAA-GFDL/MOM6@373662e32 Fix 9 misspellings in MOM_parameter_doc files
- NOAA-GFDL/MOM6@7990526c6 Add missing spaces in 53 strings
- NOAA-GFDL/MOM6@d4bf825f9 Add clocks timing MOM_end and MOM_save_restart