### PR TITLE
ocean_only: Fix KPP answers to 20251231

### DIFF
--- a/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
+++ b/ocean_only/CVmix_SCM_tests/common_KPP/MOM_input
@@ -296,6 +296,11 @@ KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.  Values of
+                                ! 20260101 or higher replace some divisions with multiplication by reciprocals.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.all
@@ -1399,7 +1399,7 @@ USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2 in Bulk Richardson Number.
 KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
                                 ! Parameter for Stokes MOST convection entrainment
-ANSWER_DATE = 99991231          ! default = 99991231
+ANSWER_DATE = 20251231          ! default = 99991231
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
                                 ! expressions that have been refactored for rotational symmetry.

--- a/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/cooling_only/KPP/MOM_parameter_doc.short
@@ -289,6 +289,10 @@ KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.all
@@ -1399,7 +1399,7 @@ USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2 in Bulk Richardson Number.
 KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
                                 ! Parameter for Stokes MOST convection entrainment
-ANSWER_DATE = 99991231          ! default = 99991231
+ANSWER_DATE = 20251231          ! default = 99991231
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
                                 ! expressions that have been refactored for rotational symmetry.

--- a/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/mech_only/KPP/MOM_parameter_doc.short
@@ -289,6 +289,10 @@ KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.all
@@ -1399,7 +1399,7 @@ USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2 in Bulk Richardson Number.
 KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
                                 ! Parameter for Stokes MOST convection entrainment
-ANSWER_DATE = 99991231          ! default = 99991231
+ANSWER_DATE = 20251231          ! default = 99991231
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
                                 ! expressions that have been refactored for rotational symmetry.

--- a/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/skin_warming_wind/KPP/MOM_parameter_doc.short
@@ -287,6 +287,10 @@ KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.all
@@ -1399,7 +1399,7 @@ USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2 in Bulk Richardson Number.
 KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
                                 ! Parameter for Stokes MOST convection entrainment
-ANSWER_DATE = 99991231          ! default = 99991231
+ANSWER_DATE = 20251231          ! default = 99991231
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
                                 ! expressions that have been refactored for rotational symmetry.

--- a/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
+++ b/ocean_only/CVmix_SCM_tests/wind_only/KPP/MOM_parameter_doc.short
@@ -289,6 +289,10 @@ KPP%
 INTERP_TYPE = "cubic"           ! default = "quadratic"
                                 ! Type of interpolation to determine the OBL depth.
                                 ! Allowed types are: linear, quadratic, cubic.
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/single_column/KPP/MOM_input
+++ b/ocean_only/single_column/KPP/MOM_input
@@ -273,6 +273,11 @@ NLT_SHAPE = "PARABOLIC"         ! default = "CVMix"
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.  Values of
+                                ! 20260101 or higher replace some divisions with multiplication by reciprocals.
 %KPP
 
 ! === module MOM_set_diffusivity ===

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.all
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.all
@@ -1366,7 +1366,7 @@ USE_KPP_LT_VT2 = False          !   [Boolean] default = False
                                 ! Flag for Langmuir turbulence enhancement of Vt2 in Bulk Richardson Number.
 KPP_CVt2 = 1.6                  !   [nondim] default = 1.6
                                 ! Parameter for Stokes MOST convection entrainment
-ANSWER_DATE = 99991231          ! default = 99991231
+ANSWER_DATE = 20251231          ! default = 99991231
                                 ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
                                 ! below 20240501 recover the answers from early in 2024, while higher values use
                                 ! expressions that have been refactored for rotational symmetry.

--- a/ocean_only/single_column/KPP/MOM_parameter_doc.short
+++ b/ocean_only/single_column/KPP/MOM_parameter_doc.short
@@ -282,6 +282,10 @@ NLT_SHAPE = "PARABOLIC"         ! default = "CVMix"
                                 !    PARABOLIC - A parablic profile, (1-sigma)^2
                                 !    CUBIC     - A cubic profile, (1-sigma)^2(1+2*sigma)
                                 !    CUBIC_LMD - The original KPP profile
+ANSWER_DATE = 20251231          ! default = 99991231
+                                ! The vintage of the order of arithmetic in the CVMix KPP calculations.  Values
+                                ! below 20240501 recover the answers from early in 2024, while higher values use
+                                ! expressions that have been refactored for rotational symmetry.
 %KPP
 
 ! === module MOM_set_diffusivity ===


### PR DESCRIPTION
This patch fixes the KPP-based experiments to ANSWER_DATE=20251231.

This is to prevent regressions from upcoming additions to the CVmix implementation of KPP.  These changes may be reverted at a later date.