### PR TITLE
MOM6: Autoconf: Minor fixes

### DIFF
--- a/coupled_AM2_LM3_SIS2/configure.coupled.ac
+++ b/coupled_AM2_LM3_SIS2/configure.coupled.ac
@@ -327,7 +327,10 @@ AS_IF([test "$with_cvmix" = yes], [
     -s ${srcdir}/src/parameterizations/CVmix"
 ])
 
-SRC_DIRS="\\
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
+AC_SUBST([MAKEDEP_FLAGS])
+
+MAKEDEP_DIRS="\\
   ${srcdir}/src \\
   ${MODEL_FRAMEWORK} \\
   ${srcdir}/config_src/external \\
@@ -338,13 +341,10 @@ SRC_DIRS="\\
 # Append user-defined source directories
 AC_ARG_VAR([EXTRA_SRC_DIRS], [Additional source code to include in build])
 AS_IF([test -n "${EXTRA_SRC_DIRS}"], [
-  SRC_DIRS="${SRC_DIRS} ${EXTRA_SRC_DIRS}"
+  MAKEDEP_DIRS="${MAKEDEP_DIRS} ${EXTRA_SRC_DIRS}"
 ])
 
-MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${SRC_DIRS}"
-
-MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
-AC_SUBST([MAKEDEP_FLAGS])
+AC_SUBST([MAKEDEP_DIRS])
 
 # Add makedep to config.status
 AC_CONFIG_COMMANDS(Makefile.dep, [make depend])

--- a/ice_ocean_SIS2/configure.ice_ocean.ac
+++ b/ice_ocean_SIS2/configure.ice_ocean.ac
@@ -327,7 +327,10 @@ AS_IF([test "$with_cvmix" = yes], [
     -s ${srcdir}/src/parameterizations/CVmix"
 ])
 
-SRC_DIRS="\\
+MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
+AC_SUBST([MAKEDEP_FLAGS])
+
+MAKEDEP_DIRS="\\
   ${srcdir}/src \\
   ${MODEL_FRAMEWORK} \\
   ${srcdir}/config_src/external \\
@@ -338,13 +341,10 @@ SRC_DIRS="\\
 # Append user-defined source directories
 AC_ARG_VAR([EXTRA_SRC_DIRS], [Additional source code to include in build])
 AS_IF([test -n "${EXTRA_SRC_DIRS}"], [
-  SRC_DIRS="${SRC_DIRS} ${EXTRA_SRC_DIRS}"
+  MAKEDEP_DIRS="${MAKEDEP_DIRS} ${EXTRA_SRC_DIRS}"
 ])
 
-MAKEDEP_FLAGS="${MAKEDEP_FLAGS} ${SRC_DIRS}"
-
-MAKEDEP_FLAGS="${MAKEDEP_FLAGS# }"
-AC_SUBST([MAKEDEP_FLAGS])
+AC_SUBST([MAKEDEP_DIRS])
 
 # Add makedep to config.status
 AC_CONFIG_COMMANDS(Makefile.dep, [make depend])

--- a/shared/config/configure.atmos_null.ac
+++ b/shared/config/configure.atmos_null.ac
@@ -43,23 +43,27 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
 # NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
+#   - We test nf_create, rather than nf90_create, since MOM6_FC_CHECK_LIB can
 #     not currently probe the Fortran 90 interfaces.
 #   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
@@ -81,15 +85,17 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
 

--- a/shared/config/configure.ice_param.ac
+++ b/shared/config/configure.ice_param.ac
@@ -43,23 +43,27 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
 # NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
+#   - We test nf_create, rather than nf90_create, since MOM6_FC_CHECK_LIB can
 #     not currently probe the Fortran 90 interfaces.
 #   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
@@ -81,15 +85,17 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
 

--- a/shared/config/configure.icebergs.ac
+++ b/shared/config/configure.icebergs.ac
@@ -43,23 +43,27 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
 # NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
+#   - We test nf_create, rather than nf90_create, since MOM6_FC_CHECK_LIB can
 #     not currently probe the Fortran 90 interfaces.
 #   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
@@ -89,15 +93,17 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
 

--- a/shared/config/configure.land_null.ac
+++ b/shared/config/configure.land_null.ac
@@ -43,23 +43,27 @@ AX_FC_CHECK_C_LIB([netcdf], [nc_create], [], [
 
 # Confirm that the Fortran compiler can link to the netCDF Fortran library.
 # NOTE:
-#   - We test nf_create, rather than nf90_create, since AX_FC_CHECK_LIB can
+#   - We test nf_create, rather than nf90_create, since MOM6_FC_CHECK_LIB can
 #     not currently probe the Fortran 90 interfaces.
 #   - nf-config does not have --libdir, so we parse the --flibs output.
-AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-  AS_UNSET([ax_fc_cv_lib_netcdff_nf_create])
-  AC_PATH_PROG([NF_CONFIG], [nf-config])
-  AS_IF([test -n "$NF_CONFIG"], [
-    AC_SUBST([LDFLAGS],
-      ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+  [], [
+    AS_UNSET([mom6_fc_cv_lib_netcdff_nf_create])
+    AC_PATH_PROG([NF_CONFIG], [nf-config])
+    AS_IF([test -n "$NF_CONFIG"], [
+      AC_SUBST([LDFLAGS],
+        ["$LDFLAGS $($NF_CONFIG --flibs | xargs -n1 | grep "^-L" | sort -u | xargs)"]
+      )
+    ], [
+      AC_MSG_ERROR([Could not find nf-config.])
+    ])
+    MOM6_FC_CHECK_LIB([netcdff], [nf_create], [], [], [], [],
+      [], [
+        AC_MSG_ERROR([Could not find netCDF Fortran library.])
+      ]
     )
-  ], [
-    AC_MSG_ERROR([Could not find nf-config.])
-  ])
-  AX_FC_CHECK_LIB([netcdff], [nf_create], [], [], [
-    AC_MSG_ERROR([Could not find netCDF Fortran library.])
-  ])
-])
+  ]
+)
 
 
 # Force 8-byte reals
@@ -81,15 +85,17 @@ AX_FC_CHECK_MODULE([fms_mod], [], [
 ])
 
 # Test for fms_init to verify FMS library linking
-AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod],
+MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
   [], [
-    AS_UNSET([ax_fc_cv_lib_FMS_fms_init])
-    AX_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [
-      AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
-      AC_SUBST([LIBS], ["-lFMS $LIBS"])
-    ],
-    [AC_MSG_ERROR([Could not find FMS library.])],
-    [-L${srcdir}/ac/deps/lib])
+    AS_UNSET([mom6_fc_cv_lib_FMS_fms_init])
+    MOM6_FC_CHECK_LIB([FMS], [fms_init], [fms_mod], [], [], [],
+      [
+        AC_SUBST([LDFLAGS], ["-L${srcdir}/ac/deps/lib $LDFLAGS"])
+        AC_SUBST([LIBS], ["-lFMS $LIBS"])
+      ], [
+        AC_MSG_ERROR([Could not find FMS library.])
+      ], [-L${srcdir}/ac/deps/lib]
+    )
   ]
 )
 


### PR DESCRIPTION
- NOAA-GFDL/MOM6@ba3da16ad Autoconf: Minor fixes
- NOAA-GFDL/MOM6@aaa12fc89 Testing: Use the top-level configure
- NOAA-GFDL/MOM6@5d0edd16c Autoconf: top-level configure + support

Autoconf files were updated to use the replacement `MOM6_FC_CHECK_LIB` macro and the updated makedep API.  AM2 and LM3 still use the legacy `AX_FC_CHECK_LIB` macro defined in `src/MOM6/ac/deps/m4`, due to an oversight on my part.  This will be sorted out in a future MOM6 commit.