### PR TITLE
*Update SCM_idealized_hurricane test case to avoid wind bug

### DIFF
--- a/ocean_only/SCM_idealized_hurricane/MOM_input
+++ b/ocean_only/SCM_idealized_hurricane/MOM_input
@@ -324,7 +324,7 @@ IDL_HURR_SCM_BR_BENCH = True    !   [Boolean] default = False
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = True             !   [Boolean] default = False
                                 ! Single Column mode switch used in the SCM idealized hurricane wind profile.
-IDL_HURR_SCM_EDGE_TAPER_BUG = True !   [Boolean] default = False
+IDL_HURR_SCM_EDGE_TAPER_BUG = False !   [Boolean] default = False
                                 ! If true and IDL_HURR_SCM is true, use a bug that does all of the tapering and
                                 ! inflow angle calculations for radii between RAD_EDGE and RAD_AMBIENT as though
                                 ! they were at RAD_EDGE.

--- a/ocean_only/SCM_idealized_hurricane/MOM_override
+++ b/ocean_only/SCM_idealized_hurricane/MOM_override
@@ -11,7 +11,7 @@
 !                                 ! Single Column mode switch used in the SCM idealized hurricane wind profile.
 ! IDL_HURR_X0 = 6.48E+05          !   [m] default = 0.0
 !                                 ! Idealized Hurricane initial X position
-! IDL_HURR_SCM_EDGE_TAPER_BUG = True !   [Boolean] default = False
+! IDL_HURR_SCM_EDGE_TAPER_BUG = False !   [Boolean] default = False
 !                                 ! If true and IDL_HURR_SCM is true, use a bug that does all of the tapering and
 !                                 ! inflow angle calculations for radii between RAD_EDGE and RAD_AMBIENT as though
 !                                 ! they were at RAD_EDGE.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.all
@@ -1822,7 +1822,7 @@ IDL_HURR_SCM_BR_BENCH = True    !   [Boolean] default = False
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = True             !   [Boolean] default = False
                                 ! Single Column mode switch used in the SCM idealized hurricane wind profile.
-IDL_HURR_SCM_EDGE_TAPER_BUG = True !   [Boolean] default = False
+IDL_HURR_SCM_EDGE_TAPER_BUG = False !   [Boolean] default = False
                                 ! If true and IDL_HURR_SCM is true, use a bug that does all of the tapering and
                                 ! inflow angle calculations for radii between RAD_EDGE and RAD_AMBIENT as though
                                 ! they were at RAD_EDGE.

--- a/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
+++ b/ocean_only/SCM_idealized_hurricane/MOM_parameter_doc.short
@@ -327,10 +327,6 @@ IDL_HURR_SCM_BR_BENCH = True    !   [Boolean] default = False
                                 ! (bug) in the wind profile meant to reproduce a previous implementation.
 IDL_HURR_SCM = True             !   [Boolean] default = False
                                 ! Single Column mode switch used in the SCM idealized hurricane wind profile.
-IDL_HURR_SCM_EDGE_TAPER_BUG = True !   [Boolean] default = False
-                                ! If true and IDL_HURR_SCM is true, use a bug that does all of the tapering and
-                                ! inflow angle calculations for radii between RAD_EDGE and RAD_AMBIENT as though
-                                ! they were at RAD_EDGE.
 
 ! === module MOM_main (MOM_driver) ===
 DAYMAX = 3.0                    !   [days]


### PR DESCRIPTION
  Updated the SCM_idealized_hurricane test case to avoid using the bug that is invoked by setting `IDL_HURR_SCM_EDGE_TAPER_BUG = True`.  With this bug, there is a large, unphysical discontinuity in the wind stresses that are used to drive the model.  The relevant changes have also been made to the MOM_parameter_doc files in the directory for this example.  The update to this test case is in preparation for the obsoleting of the `IDL_HURR_SCM_EDGE_TAPER_BUG` flag, but it does change the  reference solutions for this test case.